### PR TITLE
Log STDOUT and STDERR

### DIFF
--- a/ShellOpsLog.sh
+++ b/ShellOpsLog.sh
@@ -120,4 +120,7 @@ stop_operation_log() {
 
 # Uncomment below to auto-start logging
 # start_operation_log -AutoStart
+
+# Uncomment below to include logging stdout and stderr using tee
+# exec > >(tee -a $OPERATION_LOG_FILE) 2>&1
 ###############################################################################


### PR DESCRIPTION
Add exec and tee commands at end (commented) to enable appending the output (stdout and stderr) of commands run to the CSV. Does not follow CSV format.